### PR TITLE
Change dialogue system

### DIFF
--- a/KNOCKturne.uproject
+++ b/KNOCKturne.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "{81ED6FBD-445E-B64F-6470-588EDBBC9024}",
+	"EngineAssociation": "5.0",
 	"Category": "",
 	"Description": "",
 	"Modules": [

--- a/Source/KNOCKturne/DialogueTableComponent.cpp
+++ b/Source/KNOCKturne/DialogueTableComponent.cpp
@@ -5,11 +5,15 @@
 
 UDialogueTableComponent::UDialogueTableComponent() {
 	FString DialogueStringTablePath = TEXT("/Game/Assets/DataTable/StringTable.StringTable");
+	FString DialogueStartIndexTablePath = TEXT("/Game/Assets/DataTable/StartIndexTable.StartIndexTable");
 	//Load StringTable
 	static ConstructorHelpers::FObjectFinder<UDataTable> DT_DIALOGUETABLE(*DialogueStringTablePath);
+	static ConstructorHelpers::FObjectFinder<UDataTable> DT_STARTINDEXTABLE(*DialogueStartIndexTablePath);
 	NTCHECK(DT_DIALOGUETABLE.Succeeded());
+	NTCHECK(DT_STARTINDEXTABLE.Succeeded());
 
 	StringTable = DT_DIALOGUETABLE.Object;
+	StartIndexTable = DT_STARTINDEXTABLE.Object;
 
 	IsEndedDialogueRows = false;
 	CurrentRow = -1;
@@ -19,10 +23,19 @@ UDialogueTableComponent::UDialogueTableComponent(FString TablePath)
 {
 	static ConstructorHelpers::FObjectFinder<UDataTable> DT_TABLE(*TablePath);
 	DialogueTable = DT_TABLE.Object;
-
 }
 
-void UDialogueTableComponent::LoadDialogueTable(FString TablePath) {
+void UDialogueTableComponent::LoadDialogueTable(FString TableName) {
+	FStartIndex* StartIndexTableRow = StartIndexTable->FindRow<FStartIndex>(*TableName, TEXT(""));
+
+	FString TablePath = "";
+	if (TableName == "Dialogue_Npc") {
+		TablePath = DialogueTables.Dialogue_Npc;
+	}
+	else if (TableName == "Dialogue_Prologue") {
+		TablePath = DialogueTables.Dialogue_Prologue;
+	}
+
 	static ConstructorHelpers::FObjectFinder<UDataTable> DT_TABLE(*TablePath);
 	DialogueTable = DT_TABLE.Object;
 	if (DialogueTable != nullptr) {
@@ -33,6 +46,9 @@ void UDialogueTableComponent::LoadDialogueTable(FString TablePath) {
 	if (DialogueRows.Num() != 0) {
 		NTLOG(Warning, TEXT("%d"), DialogueRows.Num());
 	}
+
+	CurrentRow = StartIndexTableRow->StringIndex - 1;
+	NTLOG(Warning, TEXT("%d"), CurrentRow);
 }
 
 FDialogueData* UDialogueTableComponent::GetDialogueTableRow(FString RowID) {
@@ -59,4 +75,8 @@ FDialogueData UDialogueTableComponent::GetNextRowDialogueTable() {
 void UDialogueTableComponent::ResetDialogueRowPointer() {
 	IsEndedDialogueRows = false;
 	CurrentRow = -1;
+}
+
+int UDialogueTableComponent::GetCurrentRow() {
+	return CurrentRow;
 }

--- a/Source/KNOCKturne/DialogueTableComponent.h
+++ b/Source/KNOCKturne/DialogueTableComponent.h
@@ -79,6 +79,13 @@ public:
 	FString KOR;
 };
 
+
+struct ADialogueTables {
+	FString Dialogue_Npc = TEXT("/Game/Assets/DataTable/Dialogue_Npc.Dialogue_Npc");
+	FString Dialogue_Prologue = TEXT("/Game/Assets/DataTable/Dialogue_Prologue.Dialogue_Prologue");
+};
+
+
 UCLASS(ClassGroup = (DataTableComponent), meta = (BlueprintSpawnableComponent))
 class KNOCKTURNE_API UDialogueTableComponent : public UActorComponent
 {
@@ -89,13 +96,17 @@ protected:
 	class UDataTable* DialogueTable;
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Table")
 	class UDataTable* StringTable;
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Table")
+	class UDataTable* StartIndexTable;
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Table")
 	class UDataTable* DialogueNpcTable;
-	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Table")
-	class UDataTable* StartIndexTable;
-
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Property")
-		bool IsEndedDialogueRows;
+	bool IsEndedDialogueRows;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	TMap<FString, FString> Dialogues;
+
+	ADialogueTables DialogueTables;
+
 
 	TArray<FDialogueData*> DialogueRows;
 	int32 DialogueRowsSize;
@@ -105,18 +116,22 @@ public:
 	UDialogueTableComponent();
 	UDialogueTableComponent(FString TablePath);
 
-	void LoadDialogueTable(FString TablePath);
-
 	FDialogueData* GetDialogueTableRow(FString RowID);
 	FString GetString(FDialogueData* DataRow);
 
 
 	UFUNCTION(BlueprintCallable)
-		FString GetStringOnBP(FDialogueData DataRow);
+	void LoadDialogueTable(FString TableName);
 
 	UFUNCTION(BlueprintCallable)
-		FDialogueData GetNextRowDialogueTable();
+	FString GetStringOnBP(FDialogueData DataRow);
 
 	UFUNCTION(BlueprintCallable)
-		void ResetDialogueRowPointer();
+	FDialogueData GetNextRowDialogueTable();
+
+	UFUNCTION(BlueprintCallable)
+	void ResetDialogueRowPointer();
+
+	UFUNCTION(BlueprintCallable)
+	int GetCurrentRow();
 };

--- a/Source/KNOCKturne/HubWorldLevelScriptActor.cpp
+++ b/Source/KNOCKturne/HubWorldLevelScriptActor.cpp
@@ -4,13 +4,8 @@
 #include "HubWorldLevelScriptActor.h"
 
 AHubWorldLevelScriptActor::AHubWorldLevelScriptActor() {
-	/*
-	NTLOG(Warning, TEXT("Hubworld Level Script"));
-
 	DialogueTableComponent = CreateDefaultSubobject<UDialogueTableComponent>(TEXT("DialogueManager"));
-	DialogueTableComponent->LoadDialogueTable("/Game/Assets/DataTable/Dialogue_Prologue.Dialogue_Prologue");
-	NTLOG(Warning, TEXT("DialogueTable is loaded"));
-	*/
+//	DialogueTableComponent->LoadDialogueTable("Dialogue_Npc");
 }
 
 void AHubWorldLevelScriptActor::BeginPlay() {

--- a/Source/KNOCKturne/PrologueLevelScriptActor.cpp
+++ b/Source/KNOCKturne/PrologueLevelScriptActor.cpp
@@ -5,5 +5,5 @@
 
 APrologueLevelScriptActor::APrologueLevelScriptActor() {
 	DialogueTableComponent = CreateDefaultSubobject<UDialogueTableComponent>(TEXT("DialogueTableComponent"));
-	DialogueTableComponent->LoadDialogueTable("/Game/Assets/DataTable/Dialogue_Prologue.Dialogue_Prologue");
+	DialogueTableComponent->LoadDialogueTable("Dialogue_Prologue");
 }


### PR DESCRIPTION
- `StartIndexTable`을 활용한 데이터 테이블 에셋 및 인덱스 탐색 시스템 구축
- `DialogueTableComponent`에 `TableName`과 `TablePath`를 매핑한 `ADialogueTables` 구조체 선언(원래 A 접두사가 붙으면 안 되는데 급해서 일단 붙임. [언리얼 접두사 규칙](https://blog.naver.com/sorang226/221751795944))
- 테이블 찾는 과정
  1. `DialogueTableComponent`에서 `StartIndexTable`과 `StringTable`을 로드함.
  2. `LoadDialogueTable(FString TableName);` 메서드를 호출하면서 매개변수로 찾고자 하는 다이얼로그 테이블명을 입력하면 `StartIndexTable` 테이블에서 해당 테이블명을 가진 행을 찾음.
  3. `ADialogueTables` 구조체에서 `TableName`에 매핑된 레퍼런스를 찾고, 해당 레퍼런스를 가진 데이터테이블 오브젝트를 로드하여 `DialogueTable` 프로퍼티에 저장.
  4. `StartIndexTable`에서 찾은 테이블 행 정보에 따라 `CurrentRow`를 초기화함.

---

수정할 내용

- `ADialogueTable` 구조체를 없애고, `DialogueTableComponent`에 `TMap<String, String>` 객체를 만들어 String-String 매핑을 해줌. 이때 `TMap`에 리플렉션을 적용해(`UPROPERTY` 키워드 활용) 에디터에서 매핑하도록 설정.
- `DialogueManagerComponent` 컴포넌트를 만들어 이를 `KNOCKturneGameInstance`의 멤버 오브젝트로 둠. 모든 `DialogueTableComponent`가 `StartIndexTable`과 `StringTable`을 부르는 작업을 반복하지 않도록 설정함.
- `DialogueTableComponent`는 `DialogueManagerComponent`의 메서드를 호출하여 원하는 테이블 정보만 불러오도록 설정.
- `DialogueTableComponent`의 함수 최적화. 이거 크런치 때 하면 될 듯?